### PR TITLE
Heroku Router

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,9 @@ gem 'octopress-paginate'
 
 # Routing Layer
 gem 'rack-rewrite', '~> 1.5.0'
+gem 'rack-contrib', '~> 1.4'
+gem 'acme_challenge', '~> 0.1'
 
 # Deployment
-gem 'rack-jekyll'
-gem 'puma'
+gem 'puma', '~> 3.6'
 gem 'typekit_domain_manager', '~> 0.1.0'
-gem 'acme_challenge'

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem 'rouge'
 gem 'jekyll-redirect-from'
 gem 'octopress-paginate'
 
+# Routing Layer
+gem 'rack-rewrite', '~> 1.5.0'
+
 # Deployment
 gem 'rack-jekyll'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     fastimage (1.7.0)
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.6)
+    git-version-bump (0.15.1)
     hike (1.2.3)
     hitimes (1.2.2)
     jekyll (2.5.3)
@@ -87,10 +88,9 @@ GEM
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
     rack (1.6.1)
-    rack-jekyll (0.5.0)
-      jekyll (>= 1.3)
-      listen (>= 1.3)
-      rack (~> 1.5)
+    rack-contrib (1.4.0)
+      git-version-bump (~> 0.15)
+      rack (~> 1.4)
     rack-rewrite (1.5.1)
     rake (10.4.2)
     rb-fsevent (0.9.4)
@@ -129,7 +129,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acme_challenge
+  acme_challenge (~> 0.1)
   bourbon
   coffee-script
   execjs
@@ -141,8 +141,8 @@ DEPENDENCIES
   kramdown
   neat
   octopress-paginate
-  puma
-  rack-jekyll
+  puma (~> 3.6)
+  rack-contrib (~> 1.4)
   rack-rewrite (~> 1.5.0)
   rake
   rouge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       jekyll (>= 1.3)
       listen (>= 1.3)
       rack (~> 1.5)
+    rack-rewrite (1.5.1)
     rake (10.4.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
@@ -142,6 +143,7 @@ DEPENDENCIES
   octopress-paginate
   puma
   rack-jekyll
+  rack-rewrite (~> 1.5.0)
   rake
   rouge
   sass

--- a/config.ru
+++ b/config.ru
@@ -42,6 +42,7 @@ use Rack::TryStatic,
     [['jpeg'], { 'Content-Type' => 'image/jpeg' }],
     [['jpg'], { 'Content-Type' => 'image/jpeg' }],
     [['zip'], { 'Content-Type' => 'application/zip' }],
+    [['pdf'], { 'Content-Type' => 'application/pdf' }],
     [['/assets'], { 'Cache-Control' => 'public', 'Vary' => 'Accept-Encoding' }]
   ]
 

--- a/config.ru
+++ b/config.ru
@@ -41,6 +41,7 @@ use Rack::TryStatic,
     [['gif'], { 'Content-Type' => 'image/gif' }],
     [['jpeg'], { 'Content-Type' => 'image/jpeg' }],
     [['jpg'], { 'Content-Type' => 'image/jpeg' }],
+    [['zip'], { 'Content-Type' => 'application/zip' }],
     [['/assets'], { 'Cache-Control' => 'public', 'Vary' => 'Accept-Encoding' }]
   ]
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 require 'acme_challenge'
 require 'rack/rewrite'
+require 'rack/deflater'
 require 'rack/contrib/try_static'
 
 use AcmeChallenge, ENV['ACME_CHALLENGE'] if ENV['ACME_CHALLENGE']
@@ -22,6 +23,7 @@ use Rack::Rewrite do
   r301 '/feed/camera-roll', '/feed/adventures-photography/'
 end
 
+use Rack::Deflater
 use Rack::TryStatic,
   urls: %w[/],
   root: 'build',

--- a/config.ru
+++ b/config.ru
@@ -1,27 +1,48 @@
-require 'rack/jekyll'
-require 'rack/rewrite'
-require 'yaml'
 require 'acme_challenge'
+require 'rack/rewrite'
+require 'rack/contrib/try_static'
 
 use AcmeChallenge, ENV['ACME_CHALLENGE'] if ENV['ACME_CHALLENGE']
 
 use Rack::Rewrite do
-  # Ensure all traffic comes through HTTPS in production
   if ENV['RACK_ENV'] == 'production'
-    r301 %r{.*}, 'https://danielgroves.net$&', :scheme => 'http'
+   r301 %r{.*}, 'https://danielgroves.net$&', :scheme => 'http'
   end
 
   r301 '/adventures-photography/2014/11/JOGLE-2/', '/adventures-photography/2014/12/JOGLE-2/$&'
   r301 '/adventures-photography/2014/10/JOGLE/', '/adventures-photography/2014/11/JOGLE/'
-  r301 %r{/([0-9]{4})/([0-9]{2})}, '/notebook'
-  r301 %r{/notebook/page/(.*)}, '/notebook/$1'
-  r301 %r{/page/(.*)}, '/notebook/$1'
+  r301 %r{^/([0-9]{4})/([0-9]{2})}, '/notebook'
+  r301 %r{^/notebook/page/(.*)}, '/notebook/$1'
+  r301 %r{^/page/(.*)}, '/notebook/$1'
   r301 '/tag', '/notebook'
   r301 '/category', '/notebook'
-  r301 %r{/camera-roll/(.*)$}, '/adventures-photography/$1'
+  r301 %r{^/camera-roll/(.*)$}, '/adventures-photography/$1'
   r301 '/camera-roll', '/adventures-photography'
-  r301 %r{/feed/camera-roll/(.*)}, '/feed/adventures-photography/$1'
+  r301 %r{^/feed/camera-roll/(.*)}, '/feed/adventures-photography/$1'
   r301 '/feed/camera-roll', '/feed/adventures-photography/'
 end
 
-run Rack::Jekyll.new
+use Rack::TryStatic,
+  urls: %w[/],
+  root: 'build',
+  try: ['.html', 'index.html', '/index.html'],
+  header_rules: [
+    [:all, {
+      'Strict-Transport-Security' => 'max-age=31536000; preload',
+      'X-Xss-Protection' => '1; mode=block',
+      'X-Content-Type-Options' => 'nosniff',
+      'X-Frame-Options' => 'DENY',
+      'Content-Security-Policy' => "default-src 'self'; font-src data: https://fonts.typekit.net; img-src 'self' https://danielgroves-net.imgix.net https://danielgroves-net-2.imgix.net https://d1238u3jnb0njy.cloudfront.net https://p.typekit.net https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://d1238u3jnb0njy.cloudfront.net https://use.typekit.net; script-src 'self' 'unsafe-inline' https://d1238u3jnb0njy.cloudfront.net https://use.typekit.net https://www.google-analytics.com; child-src https://a.tiles.mapbox.com; frame-src https://a.tiles.mapbox.com;"
+    }],
+    [['html'], { 'Content-Type' => 'text/html; charset=utf-8'}],
+    [['css'], { 'Content-Type' => 'text/css'}],
+    [['js'], { 'Content-Type' => 'text/javascript' }],
+    [['png'], { 'Content-Type' => 'image/png' }],
+    [['gif'], { 'Content-Type' => 'image/gif' }],
+    [['jpeg'], { 'Content-Type' => 'image/jpeg' }],
+    [['jpg'], { 'Content-Type' => 'image/jpeg' }]
+  ]
+
+  run lambda { |env|
+    [404, { 'Content-Type' => 'text/html' }, File.open('build/404.html', File::RDONLY)]
+  }

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,27 @@
 require 'rack/jekyll'
+require 'rack/rewrite'
 require 'yaml'
 require 'acme_challenge'
 
 use AcmeChallenge, ENV['ACME_CHALLENGE'] if ENV['ACME_CHALLENGE']
+
+use Rack::Rewrite do
+  # Ensure all traffic comes through HTTPS in production
+  if ENV['RACK_ENV'] == 'production'
+    r301 %r{.*}, 'https://danielgroves.net$&', :scheme => 'http'
+  end
+
+  r301 '/adventures-photography/2014/11/JOGLE-2/', '/adventures-photography/2014/12/JOGLE-2/$&'
+  r301 '/adventures-photography/2014/10/JOGLE/', '/adventures-photography/2014/11/JOGLE/'
+  r301 %r{/([0-9]{4})/([0-9]{2})}, '/notebook'
+  r301 %r{/notebook/page/(.*)}, '/notebook/$1'
+  r301 %r{/page/(.*)}, '/notebook/$1'
+  r301 '/tag', '/notebook'
+  r301 '/category', '/notebook'
+  r301 %r{/camera-roll/(.*)$}, '/adventures-photography/$1'
+  r301 '/camera-roll', '/adventures-photography'
+  r301 %r{/feed/camera-roll/(.*)}, '/feed/adventures-photography/$1'
+  r301 '/feed/camera-roll', '/feed/adventures-photography/'
+end
 
 run Rack::Jekyll.new

--- a/config.ru
+++ b/config.ru
@@ -40,7 +40,8 @@ use Rack::TryStatic,
     [['png'], { 'Content-Type' => 'image/png' }],
     [['gif'], { 'Content-Type' => 'image/gif' }],
     [['jpeg'], { 'Content-Type' => 'image/jpeg' }],
-    [['jpg'], { 'Content-Type' => 'image/jpeg' }]
+    [['jpg'], { 'Content-Type' => 'image/jpeg' }],
+    [['/assets'], { 'Cache-Control' => 'public', 'Vary' => 'Accept-Encoding' }]
   ]
 
   run lambda { |env|

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -61,7 +61,7 @@
         }, config.scriptTimeout);
         var d = false;
         var tk = document.createElement('script');
-        tk.src = '//use.typekit.net/' + config.kitId + '.js';
+        tk.src = 'https://use.typekit.net/' + config.kitId + '.js';
         tk.type = 'text/javascript';
         tk.async = 'true';
         tk.onload = tk.onreadystatechange = function() {

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -61,7 +61,7 @@
         }, config.scriptTimeout);
         var d = false;
         var tk = document.createElement('script');
-        tk.src = 'https://use.typekit.net/' + config.kitId + '.js';
+        tk.src = '//use.typekit.net/' + config.kitId + '.js';
         tk.type = 'text/javascript';
         tk.async = 'true';
         tk.onload = tk.onreadystatechange = function() {


### PR DESCRIPTION
Route URLs on Heroku to match the routing rules I've previously uses in nginx. 

For the sake of transparency, the NGINX config was: 

```
server {
	server_name danielgroves.net www.danielgroves.net;
	rewrite ^ https://$server_name$request_uri? permanent;
}

server {
        listen 443 default_server ssl;

        ssl_certificate /etc/letsencrypt/live/danielgroves.net/fullchain.pem;
        ssl_certificate_key /etc/letsencrypt/live/danielgroves.net/privkey.pem;

	ssl_dhparam /etc/nginx/dhparams/danielgroves.net.pem;

	ssl_prefer_server_ciphers on;
   	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
	ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';

	ssl_session_cache shared:SSL:50m;
	ssl_session_timeout 5m;

        root /home/www-data/danielgroves.net/;
        index index.html index.xml;
        server_name danielgroves.net www.danielgroves.net;

	#rewrite "/notebook/([0-9]{4})/([0-9]{2})/" /notebook;
	rewrite ^/adventures-photography/2014/11/JOGLE-2/ /adventures-photography/2014/12/JOGLE-2/ permanent;
	rewrite ^/adventures-photography/2014/10/JOGLE/ /adventures-photography/2014/11/JOGLE/ permanent;
        rewrite "^/([0-9]{4})/([0-9]{2})" /notebook$uri permanent;
        rewrite ^/notebook/page/(.*) /notebook/$1 permanent;
        rewrite ^/page/(.*) /notebook/$1 permanent;
        rewrite ^/tag /notebook;
        rewrite ^/category /notebook permanent;
	rewrite ^/camera-roll/(.*)$ /adventures-photography/$1 permanent;
	rewrite ^/camera-roll /adventures-photography permanent;
	rewrite ^/feed/camera-roll/(.*) /feed/adventures-photography/$1 permanent;
	rewrite ^/feed/camera-roll /feed/adventures-photography/ permanent;

	server_tokens off;

	add_header Content-Security-Policy "default-src 'self'; font-src data: https://use.typekit.net; img-src 'self' https://d1238u3jnb0njy.cloudfront.net https://p.typekit.net https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://d1238u3jnb0njy.cloudfront.net https://use.typekit.net; script-src 'self' 	'unsafe-inline' https://d1238u3jnb0njy.cloudfront.net https://use.typekit.net https://www.google-analytics.com; child-src https://a.tiles.mapbox.com; frame-src https://a.tiles.mapbox.com;";
	add_header X-Frame-Options DENY;
	add_header X-Content-Type-Options "nosniff" always;
	add_header X-Xss-Protection "1; mode=block" always;
	add_header Strict-Transport-Security "max-age=31536000; preload";

        location ~ /\. {
                deny all;
        }

        location ^~ /.well-known/ {
                allow all;
        }

        location ~* /(?:uploads|files)/.*\.php$ {
                deny all;
        }

        location ~* ^.+\.(ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
                access_log off;
                log_not_found off;
                expires 1y;
                add_header Cache-Control public;
        }

	location ~* ^.+\.(css|js)$ {
		access_log off;
		log_not_found on;
		expires 2w;
		add_header Cache-Control public;
		add_header Vary Accept-Encoding;
	}

        location / {
		add_header Vary Accept-Encoding;
                try_files $uri $uri/ $uri/index.html =404;
        }

        error_page 404 /404.html;
        location 404.html {
                internal;
        }
}
```