### PR TITLE
Fixup: makes URLs absolute for sitemap.xml (fixes #17)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ permalink: /:categories/:year/:month/:title
 name: Daniel Groves
 description: 'Photographer, Adventurer, and Developer who is addicted to the mountains.'
 email: 'hello@danielgroves.net'
+url: 'https://danielgroves.net'
 
 opengraph:
   page: https://www.facebook.com/danielgrovesphotography

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,3 +1,5 @@
+url: 'http://localhost:4000'
+
 static_path: '/assets'
 styles_path: '/styles'
 scripts_path: '/scripts'


### PR DESCRIPTION
The jekyll-sitemap gem will automatically prepend the URL from the site.url configuration attribute to any sitemap URLs ensuring they're absolute and thus keeping Google happy.