### PR TITLE
Fixup: Removes references to apple touch icons

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -20,11 +20,6 @@
     <link rel="alternate" type="application/rss+xml" title="Notebook Feed" href="/feed/notebook/">
     <link rel="alternate" type="application/rss+xml" title="Adventures and Photography Feed" href="/feed/adventures-photography">
 
-    <link rel="apple-touch-icon-precomposed" href="{{ site.static_path }}/images/brand/iOS/icon_57x57.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.static_path }}/images/brand/iOS/icon_72x72.png">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.static_path }}/images/brand/iOS/icon_57x57@2x.png">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.static_path }}/images/brand/iOS/icon_72x72@2x.png">
-
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:site_name" content="{{ site.name }}" />
     <meta property="og:description" content="{% if page.excerpt != nil %}{{ page.excerpt }}{% else %}{{ site.description }}{% endif %}" />


### PR DESCRIPTION
Multiple Apple iOS icons were referenced which don't exist on any origin server.
This removes those references.