### PR TITLE
Fixes RSS Feeds 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,12 @@ namespace :dev do
     clean
     jekyll "serve --config _config.yml,_config_dev.yml --watch --future --drafts"
   end
+
+  desc "Build the Jekyll site using the development configuration."
+  task :build do
+    clean
+    jekyll "build --config _config.yml,_config_dev.yml"
+  end
 end
 
 desc "Build the site with the production configuration."

--- a/config.ru
+++ b/config.ru
@@ -29,7 +29,7 @@ use Rack::Deflater
 use Rack::TryStatic,
   urls: %w[/],
   root: 'build',
-  try: ['.html', 'index.html', '/index.html'],
+  try: ['.html', 'index.html', '/index.html', 'index.xml', '/index.xml'],
   header_rules: [
     [:all, {
       'Strict-Transport-Security' => 'max-age=31536000; preload',
@@ -47,6 +47,7 @@ use Rack::TryStatic,
     [['jpg'], { 'Content-Type' => 'image/jpeg' }],
     [['zip'], { 'Content-Type' => 'application/zip' }],
     [['pdf'], { 'Content-Type' => 'application/pdf' }],
+    [['xml'], { 'Content-Type' => 'application/rss+xml' }],
     [['/assets'], { 'Cache-Control' => 'public', 'Vary' => 'Accept-Encoding' }]
   ]
 

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Then simply go to [localhost:4000][localhost] in your browser.
 Other rake tasks are:
 * `version` - Jekyll version number.
 * `dev:watch` - Start the Jekyll server in watch mode with future and draft posts. Loads the `_config_dev.yml` file to override production values with development values.
+* `dev:build` - Builds the site with the default options. Loads the `_config_dev.yml` file to override production values with development values.
 * `deploy` - Do a production build.
 * `typekit:add_domain` - Adds a domain to a typekit kit whitelist based on your environment.
 * `typekit:remove_domain` - Removes a domain from a typekit kit whitelist based on your environment.


### PR DESCRIPTION
RSS feeds there not being served, instead giving a 404 error. 

The Heroku routing layer was missing knowledge of how to handle XML files. This has been fixed by serving `index.xml` files by default when they're present in a directory, and by setting the `Content-Type` header for XML files to `application/rss+xml`. 