### PR TITLE
Fixes Series Links

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -51,7 +51,7 @@ layout: stark
 
           <ol>
             {% for post in series_posts reversed %}
-              <li><a href="{{ post.permalink }}" title="">{{ post.title }}</a>: <em>{{ post.excerpt }}</em></li>
+              <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>: <em>{{ post.excerpt }}</em></li>
             {% endfor %}
           </ol>
         </section>


### PR DESCRIPTION
`{{ post.permalink }}` was not returning the path of the posts which resulted in
broken links. This has been fixed by swapping it to `{{ post.url }}`