### PR TITLE
Fixes Jekyll plugins repeatedly parsing the configuration.

### DIFF
--- a/src/_plugins/image-tag.rb
+++ b/src/_plugins/image-tag.rb
@@ -19,17 +19,17 @@ class ImageTag < Liquid::Tag
         @alt = attribute.sub(/^alt: /, '')
       end
     end
+  end
 
-    @config = Jekyll.configuration({})['imgix']
+  def render(context)
+    @config = context.registers[:site].config['imgix']
 
     if @watermark
       @url = "#{@config['main_images']}#{@src}"
     else
       @url = "#{@config['metadata_images']}#{@src}"
     end
-  end
 
-  def render(context)
     img = "<img data-src=\"#{@url}.jpg\" alt=\"#{@alt}\" class=\"imgix-fluid\"/>"
     img+= "<noscript><img src=\"#{@url}.jpg\" alt=\"#{@alt}\" /></noscript>"
   end

--- a/src/_plugins/tag_mapbox.rb
+++ b/src/_plugins/tag_mapbox.rb
@@ -3,37 +3,37 @@ module Jekyll
     def initialize(tag_name, text, tokens)
       super
       @text = text.strip
-      @config = Jekyll.configuration({})['mapbox']
     end
     
-    def build_url()
-      url = "https://a.tiles.mapbox.com/v4/#{@config['id_prefix']}#{@text}/"
+    def build_url(config)
+      url = "https://a.tiles.mapbox.com/v4/#{config['id_prefix']}#{@text}/"
       
-      if (@config['options']['zoompan'])
+      if (config['options']['zoompan'])
         url += "zoompan,"
       end
       
-      if (@config['options']['zoomwheel'])
+      if (config['options']['zoomwheel'])
         url += "zoomwheel,"
       end
       
-      if (@config['options']['geocoder'])
+      if (config['options']['geocoder'])
         url += "geocoder,"
       end
       
-      if (@config['options']['link'])
+      if (config['options']['link'])
         url += "share,"
       end
       
       url = url.chop
       
-      url += ".html?access_token=#{@config['access_token']}"
+      url += ".html?access_token=#{config['access_token']}"
       
       url 
     end
     
     def render(context)
-      "<iframe width='100%' height='800px' frameBorder='0' src='#{build_url()}'></iframe>"
+      config = context.registers[:site].config['mapbox']
+      "<iframe width='100%' height='800px' frameBorder='0' src='#{build_url(config)}'></iframe>"
     end
   end
 end


### PR DESCRIPTION
`Jekyll.configuration({})` causes Jekyll to parse the configuration again. This
has been swapped for the use of the running `context` which prevents this from
happening.